### PR TITLE
Fixed broken link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,1 +1,4 @@
-Documentation can be found [on the Zenoss wiki](http://wiki.zenoss.org/ZenPack:OpenStack_Cloud_Monitor).
+Documentation can be found on the Zenoss wiki:
+
+- [OpenStack (Provider View)](http://wiki.zenoss.org/ZenPack:OpenStack_(Provider_View)
+- [OpenStack (Tenant View)](http://wiki.zenoss.org/ZenPack:OpenStack_(Tenant_View)


### PR DESCRIPTION
Fixed broken URL to documentation by replacing it with 2 links to the provider and tenant view docs.
