### PR TITLE
fix "AttributeError: publicIps" in DV adapter

### DIFF
--- a/ZenPacks/zenoss/OpenStack/__init__.py
+++ b/ZenPacks/zenoss/OpenStack/__init__.py
@@ -70,14 +70,22 @@ def getOpenStackServer(self):
 
     catalog = ICatalogTool(self.dmd)
     for record in catalog.search('ZenPacks.zenoss.OpenStack.Server.Server'):
-        server = record.getObject()
+        try:
+            server = record.getObject()
+        except Exception:
+            continue
+
         server_ips = set()
 
-        if server.publicIps:
-            server_ips.update(server.publicIps)
+        try:
+            if server.publicIps:
+                server_ips.update(server.publicIps)
 
-        if server.privateIps:
-            server_ips.update(server.privateIps)
+            if server.privateIps:
+                server_ips.update(server.privateIps)
+        except AttributeError:
+            # ZPS-5852: Somehow there may be servers without these attributes.
+            continue
 
         if server_ips.intersection(device_ips):
             return server


### PR DESCRIPTION
Impact was seen to be logging the following exception in the field. I
don't know what cirumstances cause objects returned from a search of
ZenPacks.zenoss.OpenStack.Server.Server to not have a publicIps
attribute, but apparently it can happen.

    2019-05-28 15:22:47,882 ERROR zen.ImpactRelationships: Not getting edge for relationship provider: {publicIps} <ZenPacks.zenoss.Impact.impactd.relations.DSVRelationshipProvider object at 0x7fc9d493d550> over <CiscoDevice at atx-87-3750-1.zenoss.loc>
    Traceback (most recent call last):
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Impact-5.5.0.0.0-dev-py2.7.egg/ZenPacks/zenoss/Impact/impactd/relations.py", line 102, in edges
        for edge in provider.getEdges():
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.Impact-5.5.0.0.0-dev-py2.7.egg/ZenPacks/zenoss/Impact/impactd/relations.py", line 199, in getEdges
        for relation in provider.relations(type=TAG_IMPACTED_BY):
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.OpenStack-1.3.0-py2.7.egg/ZenPacks/zenoss/OpenStack/dynamicview/adapters.py", line 66, in relations
        server = self._adapted.getOpenStackServer()
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.OpenStack-1.3.0-py2.7.egg/ZenPacks/zenoss/OpenStack/__init__.py", line 76, in getOpenStackServer
        if server.publicIps:
    AttributeError: publicIps

Fixes ZPS-5852.