### PR TITLE
Fix traceback when modeling Novahost device

### DIFF
--- a/ZenPacks/zenoss/OpenStack/apiclients/ssl.py
+++ b/ZenPacks/zenoss/OpenStack/apiclients/ssl.py
@@ -29,8 +29,7 @@ from twisted.python.failure import Failure
 from twisted.web.iweb import IPolicyForHTTPS
 from twisted.internet.ssl import CertificateOptions
 from twisted.internet._sslverify import (
-    ClientTLSOptions, _maybeSetHostNameIndication,
-    SSL_CB_HANDSHAKE_START, SSL_CB_HANDSHAKE_DONE)
+    ClientTLSOptions, SSL_CB_HANDSHAKE_START, SSL_CB_HANDSHAKE_DONE)
 from twisted.web.client import BrowserLikePolicyForHTTPS
 
 from zope.interface.declarations import implementer
@@ -200,7 +199,7 @@ class PermissiveClientTLSOptions(ClientTLSOptions):
     # rather than service_identity.pyopenssl.verify_hostname.
     def _identityVerifyingInfoCallback(self, connection, where, ret):
         if where & SSL_CB_HANDSHAKE_START:
-            _maybeSetHostNameIndication(connection, self._hostnameBytes)
+            connection.set_tlsext_host_name(self._hostnameBytes)
         elif where & SSL_CB_HANDSHAKE_DONE:
             try:
                 verifyHostname(connection, self._hostnameASCII)

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.zenoss.OpenStack"
-VERSION = "1.3.1"
+VERSION = "1.3.2"
 AUTHOR = "Zenoss"
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']
 PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.OpenStack']
 INSTALL_REQUIRES = []
-COMPAT_ZENOSS_VERS = ">=3"
+COMPAT_ZENOSS_VERS = ">=6.3.2"
 PREV_ZENPACK_NAME = ""
 # STOP_REPLACEMENTS
 ################################


### PR DESCRIPTION
ZPS-7069

In Twisted 19.10.0 _maybeSetHostNameIndication removed due to updates
in the OpenSSL library twisted uses. I've checked and starting
from 6.3.2 probably even earlier I didn't get to the bottom we have
OpenSSL library updated so shouldn't be problems with backward compatibility
with older platform.